### PR TITLE
Change font type and size

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -15,6 +15,7 @@ Window {
     property bool isOmni: false;
     property string omniQuery: "";
     property string currentFile: "scratch.md";
+    property int fontSizeEditing: 11;
 
     EditUtils {
         id: utils
@@ -152,7 +153,9 @@ Window {
                 textMargin: 12;
                 width:1404;
                 textFormat: mode == 0 ? TextEdit.RichText : TextEdit.PlainText;
-                font.family: mode == 0 ? "Noto Sans" : "Noto Mono";
+                //font.family: mode == 0 ? "Noto Sans" : "Noto Mono";
+		font.family: mode == 0 ? "Noto Serif" : "Hack";
+		//font.family: mode == 0 ? "Latin Modern Roman" : "Hack";
                 text: mode == 0 ? utils.markdown(doc) : doc;
                 focus: !isOmni;
                 Component {
@@ -161,7 +164,7 @@ Window {
                 }
                 cursorDelegate: curDelegate;
                 readOnly: mode == 0 ? true : false;
-                font.pointSize: mode == 0 ? 12 : 18;
+                font.pointSize: mode == 0 ? 12 : fontSizeEditing;
 
                 onLinkActivated: {
                     console.log("Link activated: " + link);


### PR DESCRIPTION
Any chance incorporating [danschrage/remarkable-keywriter](https://github.com/danschrage/remarkable-keywriter/commit/56d341c339993c1016fb3097371b024c5bd2d849) edit mode font decrease? I.e. preview keep 12, but edit decrease to 11? The edit mode size seems too large. Or not worth it?

Or add configuration to tweak font size per install? [@Eeems](https://github.com/toltec-dev/toltec/issues/544#issuecomment-1025221809)